### PR TITLE
Replace backquote with the diactric sign  for anf

### DIFF
--- a/configure.html
+++ b/configure.html
@@ -196,24 +196,24 @@
                                 </div>
 
                                 <div class="form-group col-md-3">
-                                    <label for="jumuaTimeout"  data-text="jumuaTimeout" title="A renseigner si une des options 'Éteindre l'écran pendant jumu`a' ou 'Afficher un rappel pendant jumu`a' est activée">
+                                    <label for="jumuaTimeout"  data-text="jumuaTimeout" title="A renseigner si une des options 'Éteindre l'écran pendant jumuʿa' ou 'Afficher un rappel pendant jumuʿa' est activée">
                                     </label> <span class="glyphicon glyphicon-info-sign"></span>
                                     <input type="text" class="form-control" id="jumuaTimeout" placeholder="Ex: 30">
                                 </div>
                             </div>
                             <div class="row">
                                 <div class="form-group col-md-3">
-                                    <label title="Si activé l'heure du Jumu`a sera la même que celle du duhr">
+                                    <label title="Si activé l'heure du Jumuʿa sera la même que celle du duhr">
                                         <input type="checkbox" id="joumouaaAsDuhr"> <span data-text="joumouaa-as-duhr"></span> <span class="glyphicon glyphicon-info-sign"></span>
                                     </label>
                                 </div>
                                 <div class="form-group col-md-3">
-                                    <label title="Si activé un écran noir sera affiché pendant jumu`a">
+                                    <label title="Si activé un écran noir sera affiché pendant jumuʿa">
                                         <input type="checkbox" id="jumuaBlackScreenEnabled"> <span data-text="jumuaBlackScreenEnabled"></span> <span class="glyphicon glyphicon-info-sign"></span>
                                     </label>
                                 </div>
                                 <div class="form-group col-md-3">
-                                    <label title="Si activé un rappel sera affiché pendant jumu`a">
+                                    <label title="Si activé un rappel sera affiché pendant jumuʿa">
                                         <input type="checkbox" id="jumuaDhikrReminderEnabled"> <span data-text="jumuaDhikrReminderEnabled"></span> <span class="glyphicon glyphicon-info-sign"></span>
                                     </label>
                                 </div>

--- a/douaa-slider-one-screen.html
+++ b/douaa-slider-one-screen.html
@@ -23,7 +23,7 @@
                 <div style="font-size: 650%">
                     <div>Astaghfiru Allah, Astaghfiru Allah, Astaghfiru Allah</div>
                     <div>Allahumma anta Essalam wa mineka Essalam, tabarakta ya dhal djalali wel ikram</div>
-                    <div>Allahumma A`inni `ala dhikrika wa chukrika wa husni `ibadatik</div>
+                    <div>Allahumma Aʿinni ʿala dhikrika wa chukrika wa husni ʿibadatik</div>
                 </div>
             </div>
         </li>
@@ -37,8 +37,8 @@
             <div class="fr">
                 <div class="title">Invocations après la prière</div>
                 <div style="font-size: 650%">
-                    La ilaha illa Allah, wahdahu la charika lah, lahu elmulku wa lahu elhamdu, wa hua `ala koulli chay in kadir, 
-                    Allahumma la  mani`a lima a`atayte, wa la mu`atia lima mana`ate, wa la yanefa`u dhal djaddi mineka eldjad
+                    La ilaha illa Allah, wahdahu la charika lah, lahu elmulku wa lahu elhamdu, wa hua ʿala koulli chay in kadir, 
+                    Allahumma la  maniʿa lima aʿatayte, wa la muʿatia lima manaʿate, wa la yanefaʿu dhal djaddi mineka eldjad
                 </div>
             </div> 
         </li>
@@ -71,7 +71,7 @@
                 <div class="title">Invocations après la prière</div>
                 <div style="font-size: 650%">
                     <div class="text-center">Bismillahi arrahmani arrahim</div>
-                    Kul a`udhu bi rabbi elfalak, mine charri ma khalak, wa mine charri ghassikine idha wakab, wa mine charri ennaffathati fi el `ukad, 
+                    Kul aʿudhu bi rabbi elfalak, mine charri ma khalak, wa mine charri ghassikine idha wakab, wa mine charri ennaffathati fi el ʿukad, 
                     wa mine charri hassidine idha hassad
                 </div>
             </div>
@@ -88,7 +88,7 @@
                 <div class="title">Invocations après la prière</div>
                 <div style="font-size: 650%">
                     <div class="text-center">Bismillahi arrahmani arrahim</div>
-                    Kul a`udhu bi rabbi nnas, maliki nnas, ilahi nnas, mine charri elwaswassi elkhannas, alladhi yuaswissu fi suduri nnas, mina eldjinnati wa nnas
+                    Kul aʿudhu bi rabbi nnas, maliki nnas, ilahi nnas, mine charri elwaswassi elkhannas, alladhi yuaswissu fi suduri nnas, mina eldjinnati wa nnas
                 </div>
             </div>
         </li> 
@@ -105,8 +105,8 @@
                 <div class="title">Invocations après la prière</div>
                 <div style="font-size: 750%">
                     Allahu la ilaha illa hua elhayu elkayum, la takhudhuhu sinatune wa la nawm, lahu ma fissmawati, wa ma fi el ardh
-                    mane dha lladhi yachfa`u `indahu, illa bi idhnih, ya`alamu ma bayna aydihim wa ma khalfahum,
-                    wa la yuhituna bi chay ine mine `ilimihi, illa bima cha a, wassi`a kursiyuhu essamawati wel ardh, wala ya uduhu hifdhohuma, wa hua el`aliu al`adhim
+                    mane dha lladhi yachfaʿu ʿindahu, illa bi idhnih, yaʿalamu ma bayna aydihim wa ma khalfahum,
+                    wa la yuhituna bi chay ine mine ʿilimihi, illa bima cha a, wassiʿa kursiyuhu essamawati wel ardh, wala ya uduhu hifdhohuma, wa hua elʿaliu alʿadhim
                 </div>
             </div>
         </li> 
@@ -122,7 +122,7 @@
                 <div class="title">Invocations après la prière</div>
                 <div style="font-size: 650%">
                     <div>Subhan Allah wal hamdu lillah wallahu akbar (33 fois)</div>
-                    <div>La ilaha illa Allah, wahdahu la charika lah, lahu elmoulku wa lahu elhamdu, wa hua `ala kulli chay in kadir</div>
+                    <div>La ilaha illa Allah, wahdahu la charika lah, lahu elmoulku wa lahu elhamdu, wa hua ʿala kulli chay in kadir</div>
                 </div>
             </div>
         </li> 

--- a/js/vendor/PrayTimes.js
+++ b/js/vendor/PrayTimes.js
@@ -121,7 +121,7 @@ function PrayTimes(method) {
 	
 	// Asr Juristic Methods
 	asrJuristics = [ 
-		'Standard',    // Shafi`i, Maliki, Ja`fari, Hanbali
+		'Standard',    // Shafiʿi, Maliki, Jaʿfari, Hanbali
 		'Hanafi'       // Hanafi
 	],
 

--- a/json/i18n.json
+++ b/json/i18n.json
@@ -46,8 +46,8 @@
     },
     "joumouaa": {
         "ar": "الجمعة",
-        "fr": "Jumu`a",
-        "en": "Jumu`a"
+        "fr": "Jumuʿa",
+        "en": "Jumuʿa"
     },
     "aid-prayer": {
         "ar": "صلاة العيد",
@@ -66,8 +66,8 @@
     },
     "asr": {
         "ar": "العصر",
-        "fr": "`Asr",
-        "en": "`Asr"
+        "fr": "ʿAsr",
+        "en": "ʿAsr"
     },
     "maghrib": {
         "ar": "المغرب",
@@ -76,8 +76,8 @@
     },
     "isha": {
         "ar": "العشاء",
-        "fr": "`Isha",
-        "en": "`Isha"
+        "fr": "ʿIsha",
+        "en": "ʿIsha"
     },
     "support": {
         "ar": "Développé par Binary Consulting SAS",
@@ -106,8 +106,8 @@
     },
     "joumoua-time": {
         "ar": "وقت الجمعة",
-        "fr": "heure du jumu`a",
-        "en": "jumu`a time"
+        "fr": "heure du jumuʿa",
+        "en": "jumuʿa time"
     },
     "min-isha": {
         "ar": "الحد الأدنى لصلاة العشاء في فصل الشتاء ",
@@ -157,7 +157,7 @@
     "enable-douaa-after-prayer": {
         "ar": "عرض  شاشة الدعاء بعد الصلاة",
         "fr": "Afficher douaa après la prière",
-        "en": "Du`a after prayer"
+        "en": "Duʿa after prayer"
     },
     "iqama-display-time": {
         "ar": "وقت عرض  شاشة الإقامة",
@@ -332,7 +332,7 @@
     "joumouaa-as-duhr": {
         "ar": "وقت الجمعة موافق لوقت الظهر",
         "fr": "L'heure du jumu'a pareil que dhuhr",
-        "en": "Jumu`a time like zuhr"
+        "en": "Jumuʿa time like zuhr"
     },
     "dst": {
         "ar": "الوقت الصيفي",
@@ -390,18 +390,18 @@
     },
     "jumuaBlackScreenEnabled": {
         "ar": "إطفاء الشاشة أثناء الجمعة",
-        "fr": "Éteindre l'écran pendant jumu`a",
-        "en": "Power off screen during jumu`a"
+        "fr": "Éteindre l'écran pendant jumuʿa",
+        "en": "Power off screen during jumuʿa"
     },
     "jumuaTimeout": {
         "ar": "المدة التقريبية للجمعة",
-        "fr": "Durée approximatif du jumu`a (prêche + prière)",
-        "en": "Approximate duration of the Jumu`a"
+        "fr": "Durée approximatif du jumuʿa (prêche + prière)",
+        "en": "Approximate duration of the Jumuʿa"
     },
     "jumuaDhikrReminderEnabled": {
         "ar": "إظهار حديث أثناء الجمعة",
-        "fr": "Afficher un rappel pendant jumu`a ",
-        "en": "Show reminder during jumu`a"
+        "fr": "Afficher un rappel pendant jumuʿa ",
+        "en": "Show reminder during jumuʿa"
     },
     "prayer-times-on-mobile": {
         "ar": "أوقات الصلاة على الهاتف المحمول",


### PR DESCRIPTION
The application uses the character "`" backquote instead of left half ring "ʿ" to transliterrate the sound "ʿAyn"

Use of ʿ helps in having a more regular display, because it does not use a single space caracter like the backquote.

https://en.wiktionary.org/wiki/%CA%BF
https://fr.wikipedia.org/wiki/%CA%BF
https://fr.wikipedia.org/wiki/%CA%BFAyn

